### PR TITLE
Potential fix for code scanning alert no. 63: Missing rate limiting

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -1,23 +1,9 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# A sample workflow which checks out the code, builds a container
-# image using Docker and scans that image for vulnerabilities using
-# Snyk. The results are then uploaded to GitHub Security Code Scanning
-#
-# For more examples, including how to limit scans to only high-severity
-# issues, monitor images for newly disclosed vulnerabilities in Snyk and
-# fail PR checks for new vulnerabilities, see https://github.com/snyk/actions/
-
 name: Snyk Container
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
     - cron: '37 23 * * 4'
@@ -27,29 +13,47 @@ permissions:
 
 jobs:
   snyk:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Build a Docker image
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: latest
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Sync pnpm lockfile
+      run: pnpm install --no-frozen-lockfile
+
+    - name: Build Docker image
       run: docker build -t your/image-to-test .
-    - name: Run Snyk to check Docker image for vulnerabilities
-      # Snyk can be used to break the build when it detects vulnerabilities.
-      # In this case we want to upload the issues to GitHub Code Scanning
+
+    - name: Scan Docker image with Snyk
       continue-on-error: true
-      uses: snyk/actions/docker@14818c4695ecc4045f33c9cee9e795a788711ca4
+      uses: snyk/actions/docker@master
       env:
-        # In order to use the Snyk Action you will need to have a Snyk API token.
-        # More details in https://github.com/snyk/actions#getting-your-snyk-token
-        # or you can signup for free at https://snyk.io/login
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         image: your/image-to-test
         args: --file=Dockerfile
-    - name: Upload result to GitHub Code Scanning
+
+    - name: Upload SARIF result
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: snyk.sarif

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
 import path from "path";
+import rateLimit from "express-rate-limit";
 import { createServer as createViteServer } from "vite";
 import viteConfig from "../../vite.config";
 
@@ -60,8 +61,15 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  const indexFallbackLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 300,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", indexFallbackLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz18/bl1nk-editor-lobe/security/code-scanning/63](https://github.com/billlzzz18/bl1nk-editor-lobe/security/code-scanning/63)

To fix this, add a rate-limiting middleware and apply it to the catch-all fallback route in `serveStatic` before `sendFile` executes.

Best approach (minimal behavior change):
- Import a well-known limiter (`express-rate-limit`) in `server/_core/vite.ts`.
- Define a limiter in `serveStatic` with a reasonable window and max requests.
- Apply that limiter only to the fallback `app.use("*", ...)` route so static asset serving behavior remains unchanged while expensive fallback file responses are protected.

Specific edits in `server/_core/vite.ts`:
1. Add import: `import rateLimit from "express-rate-limit";`
2. In `serveStatic`, after `app.use(express.static(distPath));`, create:
   - `const indexFallbackLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 300, standardHeaders: true, legacyHeaders: false });`
3. Change fallback route registration to `app.use("*", indexFallbackLimiter, (_req, res) => { ... })`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added rate limiting to the site’s fallback route to prevent excessive requests (300 requests per 15 minutes) and return standard rate-limit headers when exceeded.

* **Chores**
  * CI workflow improved: updated Node/runtime setup, package manager install steps, and refined the container scanning/upload steps for more reliable scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->