### PR TITLE
fix(docker): upgrade node base image to fix CVE-2025-55131 and CVE-2026-31789

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Frontend Dockerfile (Next.js)
-FROM node:18-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/server/Dockerfile.websocket
+++ b/server/Dockerfile.websocket
@@ -1,5 +1,5 @@
 # WebSocket Server Dockerfile
-FROM node:18-alpine
+FROM node:24-alpine
 
 # Set working directory
 WORKDIR /app

--- a/server/nodeserver/Dockerfile
+++ b/server/nodeserver/Dockerfile
@@ -1,5 +1,5 @@
 # Integration Server Dockerfile
-FROM node:18-alpine
+FROM node:24-alpine
 
 # Set working directory
 WORKDIR /app

--- a/server/nodeserver/package.json
+++ b/server/nodeserver/package.json
@@ -40,7 +40,7 @@
     "@types/morgan": "^1.9.9"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "integration",

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "@types/uuid": "^9.0.7"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "websocket",


### PR DESCRIPTION
## Summary
- Bump the `node:18-alpine` base image to `node:24-alpine` in `Dockerfile`, `server/Dockerfile.websocket`, and `server/nodeserver/Dockerfile` to pick up the fix for CVE-2025-55131 (race condition in the `vm` module's timeout handling, fixed in node 20.20.0+/22.22.0+/24.13.0+/25.3.0+) and the patched OpenSSL packages that resolve CVE-2026-31789 in the Alpine base layer.
- Raise `engines.node` from `>=18.0.0` to `>=20.0.0` in `server/package.json` and `server/nodeserver/package.json` to match the new minimum supported runtime.

## Test plan
- [ ] CI build/lint/test pipeline passes on the updated Node base image
- [ ] Docker images build successfully with `node:24-alpine`
- [ ] Application smoke test (frontend, websocket server, integration server) still runs correctly on Node 24


---
_Generated by [Claude Code](https://claude.ai/code/session_01FkE7Hk6fa1c7adC9zZM9Nr)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Docker base images to `node:24-alpine` and raise the minimum Node version to `>=20` to patch CVE-2025-55131 (`vm` timeout race) and CVE-2026-31789 (OpenSSL in Alpine).

- **Dependencies**
  - Update all Dockerfiles (frontend, websocket, integration) to `node:24-alpine`.
  - Set `engines.node` to `>=20.0.0` in `server/package.json` and `server/nodeserver/package.json`.

- **Migration**
  - Ensure CI and runtime use Node 20+.
  - Rebuild Docker images to pull `node:24-alpine`.

<sup>Written for commit 70694da4d4a260d62fcd8a26be8fc7caa8ed451c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bl1nk-bot/bl1nk-editor-lobe/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images to a newer Node.js base image across the app and server images.
  * Raised the minimum supported Node.js version to 20+ for server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->